### PR TITLE
allow writing cronjobs into /etc/cron.d/

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,27 @@ Available variables are listed below, along with default values (see `defaults/m
         hour: "1"
       }
 
+If you want to install the cronjobs into /etc/cron.d/ :
+
+    elasticsearch_curator_cron_jobs:
+      - {
+        name: "Delete old elasticsearch indices.",
+        job: "/usr/local/bin/curator delete --older-than 30",
+        user: "root",
+        cron_file: "curator_cronjob",
+        minute: "0",
+        hour: "1"
+      }
+      - {
+        name: "Close old elasticsearch indices.",
+        job: "/usr/local/bin/curator close --older-than 14",
+        minute: "30",
+        user: "root",
+        cron_file: "curator_cronjob",
+        minute: "0",
+        hour: "1"
+      }
+
 A list of cron jobs to use curator to prune, optimize, close, and otherwise maintain your Elasticsearch indexes. If you're connecting to an Elasticsearch server on a different host/port than `localhost` and `9200`, you need to add `--host [hostname]` and/or `--port [port]` to the jobs. More documentation is available on the [Elasticsearch Curator wiki](https://github.com/elasticsearch/curator/wiki/Examples). You can add any of `minute`, `hour`, `day`, `weekday`, and `month` to the cron jobs—values that are not explicitly set will default to `*`.
 
 ## Dependencies

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,9 +15,26 @@
   cron:
     name: "{{ item.name }}"
     job: "{{ item.job }}"
+    state: "{{ item.state | default('present') }}"
     minute: "{{ item.minute | default('*') }}"
     hour: "{{ item.hour | default('*') }}"
     day: "{{ item.day | default('*') }}"
     weekday: "{{ item.weekday | default('*') }}"
     month: "{{ item.month | default('*') }}"
   with_items: elasticsearch_curator_cron_jobs
+  when: elasticsearch_curator_cron_jobs.0.cron_file is undefined and elasticsearch_curator_cron_jobs.0.user is undefined
+
+  - name: Configure cron jobs for Elasticsearch Curator - into etc_cron_d.
+  cron:
+    name: "{{ item.name }}"
+    job: "{{ item.job }}"
+    user: "{{ item.user | default('root') }}"
+    cron_file: "{{ item.cron_file | default('curator') }}"
+    state: "{{ item.state | default('present') }}"
+    minute: "{{ item.minute | default('*') }}"
+    hour: "{{ item.hour | default('*') }}"
+    day: "{{ item.day | default('*') }}"
+    weekday: "{{ item.weekday | default('*') }}"
+    month: "{{ item.month | default('*') }}"
+  with_items: elasticsearch_curator_cron_jobs
+  when: elasticsearch_curator_cron_jobs.0.cron_file is defined and elasticsearch_curator_cron_jobs.0.user is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,10 +21,10 @@
     day: "{{ item.day | default('*') }}"
     weekday: "{{ item.weekday | default('*') }}"
     month: "{{ item.month | default('*') }}"
-  with_items: elasticsearch_curator_cron_jobs
+  with_items: "{{ elasticsearch_curator_cron_jobs }}"
   when: elasticsearch_curator_cron_jobs.0.cron_file is undefined and elasticsearch_curator_cron_jobs.0.user is undefined
 
-  - name: Configure cron jobs for Elasticsearch Curator - into etc_cron_d.
+- name: Configure cron jobs for Elasticsearch Curator - into etc_cron_d.
   cron:
     name: "{{ item.name }}"
     job: "{{ item.job }}"
@@ -36,5 +36,5 @@
     day: "{{ item.day | default('*') }}"
     weekday: "{{ item.weekday | default('*') }}"
     month: "{{ item.month | default('*') }}"
-  with_items: elasticsearch_curator_cron_jobs
+  with_items: "{{ elasticsearch_curator_cron_jobs }}"
   when: elasticsearch_curator_cron_jobs.0.cron_file is defined and elasticsearch_curator_cron_jobs.0.user is defined


### PR DESCRIPTION
Hi!

Thanks for a great role - almost exactly what I wanted :)

<pre>
when: elasticsearch_curator_cron_jobs.0.cron_file is undefined and elasticsearch_curator_cron_jobs.0.user is undefined
</pre>


The conditional only checks if the first entry in the variable has cron_file and user defined, if so it will write all the cronjobs into /etc/cron.d/ instead of /var/spool/cron/root

Also some quoting to remove errors with ansible 2.0 and allow setting the cronjob to absent if one wants to remove a cronjob.
