### PR TITLE
Curator 4.0 is no longer compatible with this cron syntax

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,10 +6,10 @@
   when: ansible_os_family == 'Debian'
 
 - name: Install Elasticsearch Curator dependencies.
-  pip: "name=argparse"
+  pip: name=argparse
 
 - name: Install Elasticsearch Curator.
-  pip: "name=elasticsearch-curator==3.5.1"
+  pip: name=elasticsearch-curator version=3.5.1
 
 - name: Configure cron jobs for Elasticsearch Curator.
   cron:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,11 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Install Elasticsearch Curator and required dependencies.
-  pip: "name={{ item }}"
-  with_items:
-    - elasticsearch-curator
-    - argparse
+- name: Install Elasticsearch Curator dependencies.
+  pip: "name=argparse"
+
+- name: Install Elasticsearch Curator.
+  pip: "name=elasticsearch-curator==3.5.1"
 
 - name: Configure cron jobs for Elasticsearch Curator.
   cron:


### PR DESCRIPTION
Stick to release 3.5.x for now. A temporary action until a 4.0 Ansible Playbook is built and tested.
