### PR TITLE
Support configuring elasticsearch-curator version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Available variables are listed below, along with default values (see `defaults/m
         minute: "30",
         hour: "1"
       }
+    elasticsearch_curator_version: 3.5.1
 
 A list of cron jobs to use curator to prune, optimize, close, and otherwise maintain your Elasticsearch indexes. If you're connecting to an Elasticsearch server on a different host/port than `localhost` and `9200`, you need to add `--host [hostname]` and/or `--port [port]` to the jobs. More documentation is available on the [Elasticsearch Curator wiki](https://github.com/elasticsearch/curator/wiki/Examples). You can add any of `minute`, `hour`, `day`, `weekday`, and `month` to the cron jobs—values that are not explicitly set will default to `*`.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,4 @@ elasticsearch_curator_cron_jobs:
     minute: 30,
     hour: 1
   }
+elasticsearch_curator_version: 3.5.1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,11 +5,17 @@
 - include: setup-Debian.yml
   when: ansible_os_family == 'Debian'
 
-- name: Install Elasticsearch Curator and required dependencies.
-  pip: "name={{ item }}"
-  with_items:
-    - elasticsearch-curator
-    - argparse
+- name: Install Elasticsearch Curator.
+  pip: name="elasticsearch-curator" version="{{ elasticsearch_curator_version }}"
+
+- name: Register python version as integer.
+  shell: python -V 2>&1 | cut -d' ' -f2 | tr -d .
+  changed_when: False
+  register: python_version
+
+- name: Install argparse dependency when it's not included in standard library.
+  pip: name="argparse"
+  when: python_version.stdout|int < 270 or (python_version.stdout|int > 299 and python_version.stdout|int  < 320)
 
 - name: Configure cron jobs for Elasticsearch Curator.
   cron:


### PR DESCRIPTION
Adds an elasticsearch_curator_version variable to support defining which
version to install and defaults it to version 3.5.1 since the role
currently doesn't support the new yml configuration file required in the
4.\* releases.

Also adds tasks to register the python version on the host and use that
to decide if the argparse pip library needs to be installed as a
dependency. It's no longer a requirement to install that dependency for
more recent Python versions because:

"As of Python >= 2.7 and >= 3.2, the argparse module is maintained
within the Python standard library. For users who still need to support
Python < 2.7 or < 3.2" - https://pypi.python.org/pypi/argparse

@geerlingguy I saw your comment on this related pull https://github.com/geerlingguy/ansible-role-elasticsearch-curator/pull/5 and hopefully this aligns w/ your outlook of having the version configurable. I went down the path of trying to consolidate the argparse dependency install into the same pip task using a dict but I think the tricky thing w/ that is choosing a default argparse version. That's when I stumbled on the info that argparse is included in standard lib for recent python versions and in turn added the conditional install here depending on the host's python version. Let me know though if you'd like to see any changes to this.
