### PR TITLE
Allow to overwrite all cron properties

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,11 +13,5 @@
 
 - name: Configure cron jobs for Elasticsearch Curator.
   cron:
-    name: "{{ item.name }}"
-    job: "{{ item.job }}"
-    minute: "{{ item.minute | default('*') }}"
-    hour: "{{ item.hour | default('*') }}"
-    day: "{{ item.day | default('*') }}"
-    weekday: "{{ item.weekday | default('*') }}"
-    month: "{{ item.month | default('*') }}"
+  args: item
   with_items: "{{ elasticsearch_curator_cron_jobs }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,5 +13,5 @@
 
 - name: Configure cron jobs for Elasticsearch Curator.
   cron:
-  args: item
+  args: "{{ item }}"
   with_items: "{{ elasticsearch_curator_cron_jobs }}"


### PR DESCRIPTION
I have one specific use case for this change: using a different user for the cron.

I couldn't find any documentation on `args` but [here is an example](https://github.com/ansible/ansible/pull/3844).